### PR TITLE
Craft 3.7+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": "^7.0 || ^8.0",
-        "craftcms/cms": "^3.1"
+        "craftcms/cms": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/fields/ReverseEntries.php
+++ b/src/fields/ReverseEntries.php
@@ -37,6 +37,11 @@ class ReverseEntries extends Entries
      */
     public function normalizeValue($value, ElementInterface $element = null)
     {
+        // Use the canonical element
+        if ($element) {
+            $element = $element->getCanonical();
+        }
+
         /** @var Element|null $element */
         $query = parent::normalizeValue($value, $element);
 
@@ -78,7 +83,7 @@ class ReverseEntries extends Entries
     {
         if (!$isNew || $element->getIsDerivative()) {
             // Get cached element
-            $entry = Craft::$app->getEntries()->getEntryById($element->id, $element->siteId);
+            $entry = Craft::$app->getEntries()->getEntryById($element->getCanonicalId(), $element->siteId);
 
             // Get old sources
             if ($entry && $entry->{$this->handle}) {

--- a/src/fields/ReverseEntries.php
+++ b/src/fields/ReverseEntries.php
@@ -76,7 +76,7 @@ class ReverseEntries extends Entries
      */
     public function beforeElementSave(ElementInterface $element, bool $isNew): bool
     {
-        if (!$isNew) {
+        if (!$isNew || $element->getIsDerivative()) {
             // Get cached element
             $entry = Craft::$app->getEntries()->getEntryById($element->id, $element->siteId);
 

--- a/src/fields/ReverseRelationsTrait.php
+++ b/src/fields/ReverseRelationsTrait.php
@@ -108,13 +108,13 @@ trait ReverseRelationsTrait
             $this->saveRelations(
                 $field,
                 $source,
-                array_merge($target->ids(), [$element->id])
+                array_merge($target->ids(), [$element->getCanonicalId()])
             );
         }
 
         // Loop through deleted sources
         foreach ($delete as $source) {
-            $this->deleteRelations($field, $source, [$element->id]);
+            $this->deleteRelations($field, $source, [$element->getCanonicalId()]);
         }
 
         Field::afterElementSave($element, $isNew);

--- a/src/fields/ReverseRelationsTrait.php
+++ b/src/fields/ReverseRelationsTrait.php
@@ -88,7 +88,7 @@ trait ReverseRelationsTrait
         }
 
         // Get sources
-        $sources = $element->getFieldValue($this->handle)->anyStatus()->all();
+        $sources = (clone $element->getFieldValue($this->handle))->anyStatus()->all();
 
         // Find out which ones to delete
         $delete = array_diff($this->oldSources, $sources);
@@ -96,7 +96,7 @@ trait ReverseRelationsTrait
         // Loop through sources
         /** @var ElementInterface $source */
         foreach ($sources as $source) {
-            $target = $source->getFieldValue($field->handle)->anyStatus();
+            $target = (clone $source->getFieldValue($field->handle))->anyStatus();
 
             // Set this element on that element
             $this->saveRelations(

--- a/src/fields/ReverseRelationsTrait.php
+++ b/src/fields/ReverseRelationsTrait.php
@@ -82,8 +82,14 @@ trait ReverseRelationsTrait
         /** @var Field $field */
         $field = Craft::$app->fields->getFieldByUid($this->targetFieldId);
 
-        // Determine if a field can save a reverse relation
-        if (!$this->canSaveReverseRelation($field)) {
+        // Skip if nothing changed, or the element is just propagating and we're not localizing relations,
+        // or if the field can't save reverse relations
+        if (
+            !$element->isFieldDirty($this->handle) ||
+            ($element->propagating && !$this->localizeRelations) ||
+            !$this->canSaveReverseRelation($field)
+        ) {
+            Field::afterElementSave($element, $isNew);
             return;
         }
 


### PR DESCRIPTION
This PR makes the following changes:

- 33a7a8f42d4f41825f7fb75f2a5a03f6310491dd: Bump Craft requirement to 3.7+ (required for some of the other changes)
- 44d6a65509cbc10f1c8dac442bef4e45e138cabc: Stop setting `anyStatus()` directly to the field value element queries; clone them first instead so it doesn’t change the field value behavior further along in the request
- bdbad35bb84d9fa7705a08d12eec5d8bce8039fa: Avoid processing reverse relation fields if they’re not dirty
- ef83d17a664ce59e20c92dc76c012c07be4596f4: Process reverse relation fields if they are new but also derivatives (drafts)
- 6acea3588d64cde89d4ea46c5090ed80d6917a1f: Fix `#27` by only working with relations on the canonical target elements (see https://github.com/robuust/craft-reverserelations/issues/27#issuecomment-905043272)