### PR TITLE
just save relations that were added instead of re-saving all relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1 - 2021-12-14
+### Changed
+- Omit saving of relations that were not modified
+
 ## 1.3.0 - 2021-08-25
 ### Changed
 - Added Craft 3.7 compatibility (thanks to @brandonkelly)

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "robuust/craft-reverserelations",
     "description": "Reverse Relations for Craft 3",
     "type": "craft-plugin",

--- a/src/fields/ReverseRelationsTrait.php
+++ b/src/fields/ReverseRelationsTrait.php
@@ -96,12 +96,15 @@ trait ReverseRelationsTrait
         // Get sources
         $sources = (clone $element->getFieldValue($this->handle))->anyStatus()->all();
 
+        // Find out which ones to add
+        $add = array_diff($sources, $this->oldSources);
+
         // Find out which ones to delete
         $delete = array_diff($this->oldSources, $sources);
 
-        // Loop through sources
-        /** @var ElementInterface $source */
-        foreach ($sources as $source) {
+        // Loop through all items that need to be added
+        /** @var ElementInterface $add */
+        foreach ($add as $source) {
             $target = (clone $source->getFieldValue($field->handle))->anyStatus();
 
             // Set this element on that element


### PR DESCRIPTION
This PR addresses an issue, where holding a lot of relations in a reverse-relation-field leads to long saving times as all relations are re-saved.
Instead, we just save the ones that were added. (like it's already done with the deleted relations)
All common relations in $sources and $oldSources will not be touched.
