### PR TITLE
Craft 3.7.17+ compatibility

### DIFF
--- a/src/fields/ReverseCategories.php
+++ b/src/fields/ReverseCategories.php
@@ -57,7 +57,7 @@ class ReverseCategories extends Categories
                     ['relations.sourceSiteId' => null],
                     ['relations.sourceSiteId' => $element->siteId],
                 ],
-            ]);
+            ])->anyStatus()->all();
 
             $inputSourceIds = $this->inputSourceIds();
             if ($inputSourceIds != '*') {

--- a/src/fields/ReverseEntries.php
+++ b/src/fields/ReverseEntries.php
@@ -62,7 +62,7 @@ class ReverseEntries extends Entries
                     ['relations.sourceSiteId' => null],
                     ['relations.sourceSiteId' => $element->siteId],
                 ],
-            ]);
+            ])->anyStatus()->all();
 
             $inputSourceIds = $this->inputSourceIds();
             if ($inputSourceIds != '*') {


### PR DESCRIPTION
This PR makes the following changes:

* Include `->anyStatus()->all();` methods on innerJoin query to resolve issue with the reverse relation field not rendering  entries when upgrading Craft CMS >= 3.7.17