### PR TITLE
Fix GQL response issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Reverse Relations plugin for Craft
 =================
 
-Plugin that allows you to show and save reverse relations in both the CP and the site.
+Plugin that allows you to show and save reverse relations in both the CP and the site. 
+It works for relations between Entries and other Entries, and for relations between Categories and other Categories. 
 
 ## Requirements
 

--- a/src/fields/ReverseEntries.php
+++ b/src/fields/ReverseEntries.php
@@ -69,7 +69,7 @@ class ReverseEntries extends Entries
                                 "[[{$relationsAlias}.sourceId]] = [[elements.id]]",
                                 [
                                     "{$relationsAlias}.targetId" => $element->id,
-                                    "{$relationsAlias}.fieldId" => $targetField->id,
+                                    "{$relationsAlias}.fieldId" => $targetField ? $targetField->id : null,
                                 ],
                                 [
                                     'or',
@@ -173,7 +173,7 @@ class ReverseEntries extends Entries
         /** @var Field $field */
         foreach (Craft::$app->fields->getAllFields(false) as $field) {
             if ($field instanceof Entries && !($field instanceof $this)) {
-                $fields[$field->uid] = $field->name.' ('.$field->handle.')';
+                $fields[$field->uid] = $field->name . ' (' . $field->handle . ')';
             }
         }
 
@@ -189,8 +189,9 @@ class ReverseEntries extends Entries
     {
         $inputSources = $this->getInputSources();
 
-        if ($inputSources == '*') {
-            return $inputSources;
+        // Fallback: If sources are empty, treat as '*'
+        if ($inputSources == '*' || empty($inputSources)) {
+            return '*';
         }
 
         $sources = [];

--- a/src/fields/ReverseEntries.php
+++ b/src/fields/ReverseEntries.php
@@ -216,41 +216,4 @@ class ReverseEntries extends Entries
 
         return $sectionIds;
     }
-
-    /**
-     * Get GraphQL type for this field
-     *
-     * @return mixed
-     */
-    public function getGraphQLType(): mixed
-    {
-        // Get the parent GraphQL type
-        $type = parent::getGraphQLType();
-
-        // Add custom resolver to ensure proper filtering
-        if (is_array($type) && isset($type['resolve'])) {
-            $originalResolver = $type['resolve'];
-            $type['resolve'] = function ($source, $arguments, $context, $info) use ($originalResolver) {
-                $result = $originalResolver($source, $arguments, $context, $info);
-
-                // Filter by source section to ensure we only get the correct entry types
-                if (is_array($result) && !empty($result)) {
-                    $sourceSectionIds = $this->inputSourceIds();
-
-                    if ($sourceSectionIds !== '*') {
-                        $filtered = array_filter($result, function ($item) use ($sourceSectionIds) {
-                            $hasSectionId = isset($item['sectionId']);
-                            $isInSection = $hasSectionId && in_array($item['sectionId'], $sourceSectionIds);
-                            return $isInSection;
-                        });
-                        $result = array_values($filtered);
-                    }
-                }
-
-                return $result;
-            };
-        }
-
-        return $type;
-    }
 }


### PR DESCRIPTION
This PR fixes to major issues with Craft CMS 5:
- Reverse relations (entries and categories) where not output in the response
- Once output, all relations where include in all reverse relations fields; the field was not filtering by allowed entry Types

Fixes #47 